### PR TITLE
Fix schema for report meetings and webinars

### DIFF
--- a/tap_zoom/schemas/report_meetings.json
+++ b/tap_zoom/schemas/report_meetings.json
@@ -102,7 +102,7 @@
     "dept": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     }
   }

--- a/tap_zoom/schemas/report_webinars.json
+++ b/tap_zoom/schemas/report_webinars.json
@@ -17,6 +17,12 @@
         "integer"
       ]
     },
+    "host_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "type": {
       "type": [
         "null",
@@ -36,6 +42,12 @@
       ]
     },
     "user_email": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "user_id": {
       "type": [
         "null",
         "string"
@@ -102,7 +114,7 @@
     "dept": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     }
   }


### PR DESCRIPTION

# Description of change
This is a fix for #3 . The exception was being thrown due to `dept` property being returned as a string but schema expected integer.

# Manual QA steps
Tested with my own zoom account and credentials.
 
# Risks
 - I'm not aware of any
 
# Rollback steps
 - revert this branch
