### PR TITLE
Use next_page_token to fix zoom tap pagination

### DIFF
--- a/tap_zoom/sync.py
+++ b/tap_zoom/sync.py
@@ -88,7 +88,7 @@ def sync_endpoint(client,
                                               child_endpoint,
                                               child_key_bag)
 
-        if endpoint.get('paginate', True) and data['next_page_token']:
+        if endpoint.get('paginate', True) and data.get('next_page_token', ''):
             # each endpoint has a different max page size, the server will send the one that is forced
             page_size = data['page_size']
             next_page_token = data['next_page_token']

--- a/tap_zoom/sync.py
+++ b/tap_zoom/sync.py
@@ -41,11 +41,11 @@ def sync_endpoint(client,
     path = endpoint['path'].format(**key_bag)
 
     page_size = 1000
-    page_number = 1
+    next_page_token = ''
     while True:
         params = {
             'page_size': page_size,
-            'page_number': page_number
+            'next_page_token': next_page_token
         }
 
         data = client.get(path,
@@ -88,10 +88,10 @@ def sync_endpoint(client,
                                               child_endpoint,
                                               child_key_bag)
 
-        if endpoint.get('paginate', True) and page_number < data.get('page_count', 1):
+        if endpoint.get('paginate', True) and data['next_page_token']:
             # each endpoint has a different max page size, the server will send the one that is forced
             page_size = data['page_size']
-            page_number += 1
+            next_page_token = data['next_page_token']
         else:
             break
 


### PR DESCRIPTION
# Description of change
`page_number` is a deprecated API param and is not being used now. Zoom doesn't take this param so it always only gets the results from the first page. To fix this issue we should use `next_page_token` instead based on Zoom document
<img width="1655" alt="image" src="https://user-images.githubusercontent.com/31524706/198752275-270b2b2c-037c-4e3e-8e15-3860db77c294.png">

# Manual QA steps
 - Tested with my own zoom account and credentials
 
# Risks
 - N/A
 
# Rollback steps
 - revert this branch
