### PR TITLE
Change reports to pull webinar_uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.2
-  * Pull webinars by UUID [#32](https://github.com/singer-io/tap-zoom/pull/32)
+  * Pull report_webinars and report_webinar_participants by UUID [#32](https://github.com/singer-io/tap-zoom/pull/32)
 
 ## 2.0.1
   * Dependabot update [#26](https://github.com/singer-io/tap-zoom/pull/26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
-## 2.0.1
-  * Pull webinars by UUID [#N](https://github.com/singer-io/tap-zoom/pull/N)
-
+## 2.0.2
+  * Pull webinars by UUID [#32](https://github.com/singer-io/tap-zoom/pull/32)
 
 ## 2.0.1
   * Dependabot update [#26](https://github.com/singer-io/tap-zoom/pull/26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## 2.0.1
+  * Pull webinars by UUID [#N](https://github.com/singer-io/tap-zoom/pull/N)
+
+
+## 2.0.1
   * Dependabot update [#26](https://github.com/singer-io/tap-zoom/pull/26)
 
 ## 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,24 @@
 
 from setuptools import setup
 
-setup(name='tap-zoom',
-      version='2.0.1',
-      description='Singer.io tap for extracting data from the Zoom API',
-      classifiers=['Programming Language :: Python :: 3 :: Only'],
-      py_modules=['tap_zoom'],
-      install_requires=[
-        'backoff==1.8.0',
-        'ratelimit==2.2.1',
-        'requests==2.31.0',
-        'singer-python==5.13.0'
-      ],
-      entry_points='''
+setup(
+    name="tap-zoom",
+    version="2.0.2",
+    description="Singer.io tap for extracting data from the Zoom API",
+    classifiers=["Programming Language :: Python :: 3 :: Only"],
+    py_modules=["tap_zoom"],
+    install_requires=[
+        "backoff==1.8.0",
+        "ratelimit==2.2.1",
+        "requests==2.31.0",
+        "singer-python==5.13.0",
+    ],
+    entry_points="""
           [console_scripts]
           tap-zoom=tap_zoom:main
-      ''',
-      packages=['tap_zoom'],
-      package_data = {
-          'tap_zoom': ['schemas/*.json'],
-      }
+      """,
+    packages=["tap_zoom"],
+    package_data={
+        "tap_zoom": ["schemas/*.json"],
+    },
 )

--- a/tap_zoom/endpoints.py
+++ b/tap_zoom/endpoints.py
@@ -1,159 +1,148 @@
-
 ENDPOINTS_CONFIG = {
-    'users': {
-        'path': 'users',
-        'pk': ['id'],
-        'data_key': 'users',
-        'forced-replication-method': 'FULL_TABLE',
-        'provides': {
-            'user_id': 'id'
-        },
-        'children': {
-            'list_meetings': {
-                'persist': False,
-                'path': 'users/{user_id}/meetings',
-                'data_key': 'meetings',
-                'provides': {
-                    'meeting_id': 'id'
-                },
-                'children': {
-                    'meetings': {
-                        'paginate': False,
-                        'path': 'meetings/{meeting_id}',
-                        'pk': ['uuid'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'provides': {
-                            'meeting_uuid': 'uuid'
-                        },
-                        'children': {
-                            'meeting_poll_results': {
-                                'paginate': False,
-                                'path': 'past_meetings/{meeting_uuid}/polls',
-                                'pk': ['meeting_uuid', 'email'],
-                                'forced-replication-method': 'FULL_TABLE',
-                                'data_key': 'questions'
+    "users": {
+        "path": "users",
+        "pk": ["id"],
+        "data_key": "users",
+        "forced-replication-method": "FULL_TABLE",
+        "provides": {"user_id": "id"},
+        "children": {
+            "list_meetings": {
+                "persist": False,
+                "path": "users/{user_id}/meetings",
+                "data_key": "meetings",
+                "provides": {"meeting_id": "id"},
+                "children": {
+                    "meetings": {
+                        "paginate": False,
+                        "path": "meetings/{meeting_id}",
+                        "pk": ["uuid"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "provides": {"meeting_uuid": "uuid"},
+                        "children": {
+                            "meeting_poll_results": {
+                                "paginate": False,
+                                "path": "past_meetings/{meeting_uuid}/polls",
+                                "pk": ["meeting_uuid", "email"],
+                                "forced-replication-method": "FULL_TABLE",
+                                "data_key": "questions",
                             }
-                        }
+                        },
                     },
-                    'meeting_registrants': {
-                        'path': 'meetings/{meeting_id}/registrants',
-                        'pk': ['meeting_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'registrants'
+                    "meeting_registrants": {
+                        "path": "meetings/{meeting_id}/registrants",
+                        "pk": ["meeting_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "registrants",
                     },
-                    'meeting_polls': {
-                        'path': 'meetings/{meeting_id}/polls',
-                        'pk': ['meeting_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'polls'
+                    "meeting_polls": {
+                        "path": "meetings/{meeting_id}/polls",
+                        "pk": ["meeting_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "polls",
                     },
-                    'meeting_questions': {
-                        'paginate': False,
-                        'path': 'meetings/{meeting_id}/registrants/questions',
-                        'pk': ['meeting_id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'ignore_zoom_error_codes': [3000]
+                    "meeting_questions": {
+                        "paginate": False,
+                        "path": "meetings/{meeting_id}/registrants/questions",
+                        "pk": ["meeting_id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "ignore_zoom_error_codes": [3000],
                     },
-                    'report_meetings': {
-                        'paginate': False,
-                        'path': 'report/meetings/{meeting_id}',
-                        'pk': ['uuid'],
-                        'forced-replication-method': 'FULL_TABLE'
+                    "report_meetings": {
+                        "paginate": False,
+                        "path": "report/meetings/{meeting_id}",
+                        "pk": ["uuid"],
+                        "forced-replication-method": "FULL_TABLE",
                     },
-                    'report_meeting_participants': {
-                        'path': 'report/meetings/{meeting_id}/participants',
-                        'pk': ['meeting_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'participants'
-                    }
-                }
+                    "report_meeting_participants": {
+                        "path": "report/meetings/{meeting_id}/participants",
+                        "pk": ["meeting_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "participants",
+                    },
+                },
             },
-            'list_webinars': {
-                'persist': False,
-                'path': 'users/{user_id}/webinars',
-                'data_key': 'webinars',
-                'ignore_zoom_error_codes': [200],
-                'provides': {
-                    'webinar_id': 'id'
-                },
-                'children': {
-                    'webinars': {
-                        'paginate': False,
-                        'path': 'webinars/{webinar_id}',
-                        'pk': ['uuid'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'provides': {
-                            'webinar_uuid': 'uuid'
+            "list_webinars": {
+                "persist": False,
+                "path": "users/{user_id}/webinars",
+                "data_key": "webinars",
+                "ignore_zoom_error_codes": [200],
+                "provides": {"webinar_id": "id"},
+                "children": {
+                    "webinars": {
+                        "paginate": False,
+                        "path": "webinars/{webinar_id}",
+                        "pk": ["uuid"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "provides": {"webinar_uuid": "uuid"},
+                        "children": {
+                            "webinar_absentees": {
+                                "path": "past_webinars/{webinar_uuid}/absentees",
+                                "pk": ["webinar_uuid", "id"],
+                                "forced-replication-method": "FULL_TABLE",
+                                "data_key": "registrants",
+                                "ignore_http_error_codes": [404],
+                            },
+                            "webinar_poll_results": {
+                                "paginate": False,
+                                "path": "past_webinars/{webinar_uuid}/polls",
+                                "pk": ["webinar_uuid", "email"],
+                                "forced-replication-method": "FULL_TABLE",
+                                "data_key": "questions",
+                            },
+                            "webinar_qna_results": {
+                                "paginate": False,
+                                "path": "past_webinars/{webinar_uuid}/qa",
+                                "pk": ["webinar_uuid", "email"],
+                                "forced-replication-method": "FULL_TABLE",
+                                "data_key": "questions",
+                            },
                         },
-                        'children': {
-                            'webinar_absentees': {
-                                'path': 'past_webinars/{webinar_uuid}/absentees',
-                                'pk': ['webinar_uuid', 'id'],
-                                'forced-replication-method': 'FULL_TABLE',
-                                'data_key': 'registrants',
-                                'ignore_http_error_codes': [404]
-                            },
-                            'webinar_poll_results': {
-                                'paginate': False,
-                                'path': 'past_webinars/{webinar_uuid}/polls',
-                                'pk': ['webinar_uuid', 'email'],
-                                'forced-replication-method': 'FULL_TABLE',
-                                'data_key': 'questions'
-                            },
-                            'webinar_qna_results': {
-                                'paginate': False,
-                                'path': 'past_webinars/{webinar_uuid}/qa',
-                                'pk': ['webinar_uuid', 'email'],
-                                'forced-replication-method': 'FULL_TABLE',
-                                'data_key': 'questions'
-                            }
-                        }
                     },
-                    'webinar_panelists': {
-                        'path': 'webinars/{webinar_id}/panelists',
-                        'pk': ['webinar_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'panelists'
+                    "webinar_panelists": {
+                        "path": "webinars/{webinar_id}/panelists",
+                        "pk": ["webinar_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "panelists",
                     },
-                    'webinar_registrants': {
-                        'path': 'webinars/{webinar_id}/registrants',
-                        'pk': ['webinar_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'registrants'
+                    "webinar_registrants": {
+                        "path": "webinars/{webinar_id}/registrants",
+                        "pk": ["webinar_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "registrants",
                     },
-                    'webinar_polls': {
-                        'path': 'webinars/{webinar_id}/polls',
-                        'pk': ['webinar_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'polls'
+                    "webinar_polls": {
+                        "path": "webinars/{webinar_id}/polls",
+                        "pk": ["webinar_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "polls",
                     },
-                    'webinar_questions': {
-                        'paginate': False,
-                        'path': 'webinars/{webinar_id}/registrants/questions',
-                        'pk': ['webinar_id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'ignore_zoom_error_codes': [3000]
+                    "webinar_questions": {
+                        "paginate": False,
+                        "path": "webinars/{webinar_id}/registrants/questions",
+                        "pk": ["webinar_id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "ignore_zoom_error_codes": [3000],
                     },
-                    'webinar_tracking_sources': {
-                        'path': 'webinars/{webinar_id}/tracking_sources',
-                        'pk': ['webinar_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'tracking_sources'
+                    "webinar_tracking_sources": {
+                        "path": "webinars/{webinar_id}/tracking_sources",
+                        "pk": ["webinar_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "tracking_sources",
                     },
-                    'report_webinars': {
-                        'paginate': False,
-                        'path': 'report/webinars/{webinar_id}',
-                        'pk': ['uuid'],
-                        'forced-replication-method': 'FULL_TABLE',
+                    "report_webinars": {
+                        "paginate": False,
+                        "path": "report/webinars/{webinar_uuid}",
+                        "pk": ["uuid"],
+                        "forced-replication-method": "FULL_TABLE",
                     },
-                    'report_webinar_participants': {
-                        'path': 'report/webinars/{webinar_id}/participants',
-                        'pk': ['webinar_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'participants'
-                    }
-                }
-            }
-        }
+                    "report_webinar_participants": {
+                        "path": "report/webinars/{webinar_uuid}/participants",
+                        "pk": ["webinar_id", "id"],
+                        "forced-replication-method": "FULL_TABLE",
+                        "data_key": "participants",
+                    },
+                },
+            },
+        },
     }
 }

--- a/tap_zoom/endpoints.py
+++ b/tap_zoom/endpoints.py
@@ -147,7 +147,7 @@ ENDPOINTS_CONFIG = {
                         'forced-replication-method': 'FULL_TABLE',
                     },
                     'report_webinar_participants': {
-                        'path': 'report/webinars/{webinar_id}/participants',
+                        'path': 'report/webinars/{webinar_uuid}/participants',
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'participants'

--- a/tap_zoom/endpoints.py
+++ b/tap_zoom/endpoints.py
@@ -106,6 +106,18 @@ ENDPOINTS_CONFIG = {
                                 'pk': ['webinar_uuid', 'email'],
                                 'forced-replication-method': 'FULL_TABLE',
                                 'data_key': 'questions'
+                            },
+                            'report_webinars': {
+                                'paginate': False,
+                                'path': 'report/webinars/{webinar_uuid}',
+                                'pk': ['uuid'],
+                                'forced-replication-method': 'FULL_TABLE',
+                            },
+                            'report_webinar_participants': {
+                                'path': 'report/webinars/{webinar_uuid}/participants',
+                                'pk': ['webinar_id', 'id'],
+                                'forced-replication-method': 'FULL_TABLE',
+                                'data_key': 'participants'
                             }
                         }
                     },
@@ -139,18 +151,6 @@ ENDPOINTS_CONFIG = {
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'tracking_sources'
-                    },
-                    'report_webinars': {
-                        'paginate': False,
-                        'path': 'report/webinars/{webinar_uuid}',
-                        'pk': ['uuid'],
-                        'forced-replication-method': 'FULL_TABLE',
-                    },
-                    'report_webinar_participants': {
-                        'path': 'report/webinars/{webinar_uuid}/participants',
-                        'pk': ['webinar_id', 'id'],
-                        'forced-replication-method': 'FULL_TABLE',
-                        'data_key': 'participants'
                     }
                 }
             }

--- a/tap_zoom/endpoints.py
+++ b/tap_zoom/endpoints.py
@@ -1,148 +1,159 @@
+
 ENDPOINTS_CONFIG = {
-    "users": {
-        "path": "users",
-        "pk": ["id"],
-        "data_key": "users",
-        "forced-replication-method": "FULL_TABLE",
-        "provides": {"user_id": "id"},
-        "children": {
-            "list_meetings": {
-                "persist": False,
-                "path": "users/{user_id}/meetings",
-                "data_key": "meetings",
-                "provides": {"meeting_id": "id"},
-                "children": {
-                    "meetings": {
-                        "paginate": False,
-                        "path": "meetings/{meeting_id}",
-                        "pk": ["uuid"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "provides": {"meeting_uuid": "uuid"},
-                        "children": {
-                            "meeting_poll_results": {
-                                "paginate": False,
-                                "path": "past_meetings/{meeting_uuid}/polls",
-                                "pk": ["meeting_uuid", "email"],
-                                "forced-replication-method": "FULL_TABLE",
-                                "data_key": "questions",
-                            }
-                        },
-                    },
-                    "meeting_registrants": {
-                        "path": "meetings/{meeting_id}/registrants",
-                        "pk": ["meeting_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "registrants",
-                    },
-                    "meeting_polls": {
-                        "path": "meetings/{meeting_id}/polls",
-                        "pk": ["meeting_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "polls",
-                    },
-                    "meeting_questions": {
-                        "paginate": False,
-                        "path": "meetings/{meeting_id}/registrants/questions",
-                        "pk": ["meeting_id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "ignore_zoom_error_codes": [3000],
-                    },
-                    "report_meetings": {
-                        "paginate": False,
-                        "path": "report/meetings/{meeting_id}",
-                        "pk": ["uuid"],
-                        "forced-replication-method": "FULL_TABLE",
-                    },
-                    "report_meeting_participants": {
-                        "path": "report/meetings/{meeting_id}/participants",
-                        "pk": ["meeting_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "participants",
-                    },
-                },
-            },
-            "list_webinars": {
-                "persist": False,
-                "path": "users/{user_id}/webinars",
-                "data_key": "webinars",
-                "ignore_zoom_error_codes": [200],
-                "provides": {"webinar_id": "id"},
-                "children": {
-                    "webinars": {
-                        "paginate": False,
-                        "path": "webinars/{webinar_id}",
-                        "pk": ["uuid"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "provides": {"webinar_uuid": "uuid"},
-                        "children": {
-                            "webinar_absentees": {
-                                "path": "past_webinars/{webinar_uuid}/absentees",
-                                "pk": ["webinar_uuid", "id"],
-                                "forced-replication-method": "FULL_TABLE",
-                                "data_key": "registrants",
-                                "ignore_http_error_codes": [404],
-                            },
-                            "webinar_poll_results": {
-                                "paginate": False,
-                                "path": "past_webinars/{webinar_uuid}/polls",
-                                "pk": ["webinar_uuid", "email"],
-                                "forced-replication-method": "FULL_TABLE",
-                                "data_key": "questions",
-                            },
-                            "webinar_qna_results": {
-                                "paginate": False,
-                                "path": "past_webinars/{webinar_uuid}/qa",
-                                "pk": ["webinar_uuid", "email"],
-                                "forced-replication-method": "FULL_TABLE",
-                                "data_key": "questions",
-                            },
-                        },
-                    },
-                    "webinar_panelists": {
-                        "path": "webinars/{webinar_id}/panelists",
-                        "pk": ["webinar_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "panelists",
-                    },
-                    "webinar_registrants": {
-                        "path": "webinars/{webinar_id}/registrants",
-                        "pk": ["webinar_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "registrants",
-                    },
-                    "webinar_polls": {
-                        "path": "webinars/{webinar_id}/polls",
-                        "pk": ["webinar_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "polls",
-                    },
-                    "webinar_questions": {
-                        "paginate": False,
-                        "path": "webinars/{webinar_id}/registrants/questions",
-                        "pk": ["webinar_id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "ignore_zoom_error_codes": [3000],
-                    },
-                    "webinar_tracking_sources": {
-                        "path": "webinars/{webinar_id}/tracking_sources",
-                        "pk": ["webinar_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "tracking_sources",
-                    },
-                    "report_webinars": {
-                        "paginate": False,
-                        "path": "report/webinars/{webinar_uuid}",
-                        "pk": ["uuid"],
-                        "forced-replication-method": "FULL_TABLE",
-                    },
-                    "report_webinar_participants": {
-                        "path": "report/webinars/{webinar_uuid}/participants",
-                        "pk": ["webinar_id", "id"],
-                        "forced-replication-method": "FULL_TABLE",
-                        "data_key": "participants",
-                    },
-                },
-            },
+    'users': {
+        'path': 'users',
+        'pk': ['id'],
+        'data_key': 'users',
+        'forced-replication-method': 'FULL_TABLE',
+        'provides': {
+            'user_id': 'id'
         },
+        'children': {
+            'list_meetings': {
+                'persist': False,
+                'path': 'users/{user_id}/meetings',
+                'data_key': 'meetings',
+                'provides': {
+                    'meeting_id': 'id'
+                },
+                'children': {
+                    'meetings': {
+                        'paginate': False,
+                        'path': 'meetings/{meeting_id}',
+                        'pk': ['uuid'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'provides': {
+                            'meeting_uuid': 'uuid'
+                        },
+                        'children': {
+                            'meeting_poll_results': {
+                                'paginate': False,
+                                'path': 'past_meetings/{meeting_uuid}/polls',
+                                'pk': ['meeting_uuid', 'email'],
+                                'forced-replication-method': 'FULL_TABLE',
+                                'data_key': 'questions'
+                            }
+                        }
+                    },
+                    'meeting_registrants': {
+                        'path': 'meetings/{meeting_id}/registrants',
+                        'pk': ['meeting_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'registrants'
+                    },
+                    'meeting_polls': {
+                        'path': 'meetings/{meeting_id}/polls',
+                        'pk': ['meeting_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'polls'
+                    },
+                    'meeting_questions': {
+                        'paginate': False,
+                        'path': 'meetings/{meeting_id}/registrants/questions',
+                        'pk': ['meeting_id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'ignore_zoom_error_codes': [3000]
+                    },
+                    'report_meetings': {
+                        'paginate': False,
+                        'path': 'report/meetings/{meeting_id}',
+                        'pk': ['uuid'],
+                        'forced-replication-method': 'FULL_TABLE'
+                    },
+                    'report_meeting_participants': {
+                        'path': 'report/meetings/{meeting_id}/participants',
+                        'pk': ['meeting_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'participants'
+                    }
+                }
+            },
+            'list_webinars': {
+                'persist': False,
+                'path': 'users/{user_id}/webinars',
+                'data_key': 'webinars',
+                'ignore_zoom_error_codes': [200],
+                'provides': {
+                    'webinar_id': 'id'
+                },
+                'children': {
+                    'webinars': {
+                        'paginate': False,
+                        'path': 'webinars/{webinar_id}',
+                        'pk': ['uuid'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'provides': {
+                            'webinar_uuid': 'uuid'
+                        },
+                        'children': {
+                            'webinar_absentees': {
+                                'path': 'past_webinars/{webinar_uuid}/absentees',
+                                'pk': ['webinar_uuid', 'id'],
+                                'forced-replication-method': 'FULL_TABLE',
+                                'data_key': 'registrants',
+                                'ignore_http_error_codes': [404]
+                            },
+                            'webinar_poll_results': {
+                                'paginate': False,
+                                'path': 'past_webinars/{webinar_uuid}/polls',
+                                'pk': ['webinar_uuid', 'email'],
+                                'forced-replication-method': 'FULL_TABLE',
+                                'data_key': 'questions'
+                            },
+                            'webinar_qna_results': {
+                                'paginate': False,
+                                'path': 'past_webinars/{webinar_uuid}/qa',
+                                'pk': ['webinar_uuid', 'email'],
+                                'forced-replication-method': 'FULL_TABLE',
+                                'data_key': 'questions'
+                            }
+                        }
+                    },
+                    'webinar_panelists': {
+                        'path': 'webinars/{webinar_id}/panelists',
+                        'pk': ['webinar_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'panelists'
+                    },
+                    'webinar_registrants': {
+                        'path': 'webinars/{webinar_id}/registrants',
+                        'pk': ['webinar_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'registrants'
+                    },
+                    'webinar_polls': {
+                        'path': 'webinars/{webinar_id}/polls',
+                        'pk': ['webinar_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'polls'
+                    },
+                    'webinar_questions': {
+                        'paginate': False,
+                        'path': 'webinars/{webinar_id}/registrants/questions',
+                        'pk': ['webinar_id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'ignore_zoom_error_codes': [3000]
+                    },
+                    'webinar_tracking_sources': {
+                        'path': 'webinars/{webinar_id}/tracking_sources',
+                        'pk': ['webinar_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'tracking_sources'
+                    },
+                    'report_webinars': {
+                        'paginate': False,
+                        'path': 'report/webinars/{webinar_uuid}',
+                        'pk': ['uuid'],
+                        'forced-replication-method': 'FULL_TABLE',
+                    },
+                    'report_webinar_participants': {
+                        'path': 'report/webinars/{webinar_id}/participants',
+                        'pk': ['webinar_id', 'id'],
+                        'forced-replication-method': 'FULL_TABLE',
+                        'data_key': 'participants'
+                    }
+                }
+            }
+        }
     }
 }

--- a/tap_zoom/schemas/report_webinar_participants.json
+++ b/tap_zoom/schemas/report_webinar_participants.json
@@ -72,6 +72,18 @@
         "null",
         "string"
       ]
+    },
+    "bo_mtg_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "participant_user_id": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }


### PR DESCRIPTION
# Description of change
Changing report webinars and participants to pull each UUID rather than ID; this means they're a child of webinars

Per the documentation, if you pass webinar_id you get only the last result per webinar, but if you pass UUID, you get the results for the UUID:
https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/reportWebinarDetails

The webinar's ID or universally unique ID (UUID).If you provide a webinar ID, the API will return a response for the latest webinar instance.If you provide a webinar UUID that begins with a / character or contains the // characters, you must double encode the webinar UUID before making an API request.

webinarId
string
The webinar's ID or universally unique ID (UUID).

If you provide a webinar ID, the API will return a response for the latest webinar instance.
If you provide a webinar UUID that begins with a / character or contains the // characters, you must [double encode](https://marketplace.zoom.us/docs/api-reference/using-zoom-apis/#meeting-id-and-uuid) the webinar UUID before making an API request.

Add new fields to participants:
https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/reportMeetingParticipants

# Manual QA steps
I built locally and ran. before, I got a total of 6 results for report_webinars, all grouped together, all with different ids.


After, I got a record for report_webinars after every webinar, closer to 50 results

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
