### PR TITLE
Remove ratelimit dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-zoom/bin/activate
-            pylint tap_zoom -d C,R,W
+            pylint tap_zoom -d C,R,W,possibly-used-before-assignment
       - run:
           name: 'Unit Tests'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2
+  * Remove ratelimit dependency [#33](https://github.com/singer-io/tap-zoom/pull/33)
+
 ## 2.0.1
   * Dependabot update [#26](https://github.com/singer-io/tap-zoom/pull/26)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zoom',
-      version='2.0.1',
+      version='2.0.2',
       description='Singer.io tap for extracting data from the Zoom API',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zoom'],

--- a/tap_zoom/client.py
+++ b/tap_zoom/client.py
@@ -7,7 +7,6 @@ import singer
 from singer import metrics
 from singer.utils import now
 from .utils import write_config
-from ratelimit import limits, RateLimitException
 from requests.exceptions import ConnectionError
 
 LOGGER = singer.get_logger()
@@ -76,13 +75,7 @@ class ZoomClient(object):
                           max_tries=8,
                           on_backoff=log_backoff_attempt,
                           factor=3)
-    @backoff.on_exception(backoff.constant,
-                          RateLimitException,
-                          max_tries=8,
-                          on_backoff=log_backoff_attempt,
-                          jitter=None,
-                          interval=30)
-    @limits(calls=300, period=60)
+
     def request(self,
                 method,
                 path=None,


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-26785
Removed redundant ratelimit integration as its functionality was already handled by custom 429 error handling and backoff. This simplifies the code without impacting functionality.

[Zoom's rate limits](https://developers.zoom.us/docs/api/rate-limits/#rate-limits-by-account-type) don't line up with the `@limits` settings of 300 requests per minute, relying on 429 should be overall more effective. 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
