### PR TITLE
[SAC-28905] - Add parent-tap-stream-id key in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0
+  * Adds parent-tap-stream-id field to catalog for child streams [#40](https://github.com/singer-io/tap-zoom/pull/40)
+
 ## 2.0.3
   * Update dependency versions for twistlock compliance
   * Adjust tests to pass in circle

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-zoom',
-      version='2.0.3',
+      version='2.1.0',
       description='Singer.io tap for extracting data from the Zoom API',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_zoom'],

--- a/tap_zoom/discover.py
+++ b/tap_zoom/discover.py
@@ -14,7 +14,7 @@ def get_field_value(stream_name, field_name, endpoints=None):
 
     for endpoint_stream_name, endpoint in endpoints.items():
         if stream_name == endpoint_stream_name:
-            return endpoint[field_name]
+            return endpoint.get(field_name)
 
         if 'children' in endpoint:
             pk = get_field_value(stream_name, field_name, endpoints=endpoint['children'])
@@ -48,6 +48,12 @@ def get_schemas():
         mdata = {"table-key-properties": pk,
                 "forced-replication-method": repl_method,
                 "inclusion": "available"}
+
+        # Check if the stream has any parent attribute
+        parent_attribute = get_field_value(stream_name, 'parent')
+        if parent_attribute:
+            mdata["parent-tap-stream-id"] = parent_attribute
+
         metadata = [{"breadcrumb": [], "metadata": mdata}]
         for prop, json_schema in schema['properties'].items():
             if prop in pk:

--- a/tap_zoom/discover.py
+++ b/tap_zoom/discover.py
@@ -49,7 +49,6 @@ def get_schemas():
                 "forced-replication-method": repl_method,
                 "inclusion": "available"}
 
-        # Check if the stream has any parent attribute
         parent_attribute = get_field_value(stream_name, 'parent')
         if parent_attribute:
             mdata["parent-tap-stream-id"] = parent_attribute

--- a/tap_zoom/endpoints.py
+++ b/tap_zoom/endpoints.py
@@ -10,6 +10,7 @@ ENDPOINTS_CONFIG = {
         },
         'children': {
             'list_meetings': {
+                'parent': 'users',
                 'persist': False,
                 'path': 'users/{user_id}/meetings',
                 'data_key': 'meetings',
@@ -18,6 +19,7 @@ ENDPOINTS_CONFIG = {
                 },
                 'children': {
                     'meetings': {
+                        'parent': 'list_meetings',
                         'paginate': False,
                         'path': 'meetings/{meeting_id}',
                         'pk': ['uuid'],
@@ -27,6 +29,7 @@ ENDPOINTS_CONFIG = {
                         },
                         'children': {
                             'meeting_poll_results': {
+                                'parent': 'meetings',
                                 'paginate': False,
                                 'path': 'past_meetings/{meeting_uuid}/polls',
                                 'pk': ['meeting_uuid', 'email'],
@@ -36,18 +39,21 @@ ENDPOINTS_CONFIG = {
                         }
                     },
                     'meeting_registrants': {
+                        'parent': 'list_meetings',
                         'path': 'meetings/{meeting_id}/registrants',
                         'pk': ['meeting_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'registrants'
                     },
                     'meeting_polls': {
+                        'parent': 'list_meetings',
                         'path': 'meetings/{meeting_id}/polls',
                         'pk': ['meeting_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'polls'
                     },
                     'meeting_questions': {
+                        'parent': 'list_meetings',
                         'paginate': False,
                         'path': 'meetings/{meeting_id}/registrants/questions',
                         'pk': ['meeting_id'],
@@ -55,12 +61,14 @@ ENDPOINTS_CONFIG = {
                         'ignore_zoom_error_codes': [3000]
                     },
                     'report_meetings': {
+                        'parent': 'list_meetings',
                         'paginate': False,
                         'path': 'report/meetings/{meeting_id}',
                         'pk': ['uuid'],
                         'forced-replication-method': 'FULL_TABLE'
                     },
                     'report_meeting_participants': {
+                        'parent': 'list_meetings',
                         'path': 'report/meetings/{meeting_id}/participants',
                         'pk': ['meeting_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
@@ -69,6 +77,7 @@ ENDPOINTS_CONFIG = {
                 }
             },
             'list_webinars': {
+                'parent': 'users',
                 'persist': False,
                 'path': 'users/{user_id}/webinars',
                 'data_key': 'webinars',
@@ -78,6 +87,7 @@ ENDPOINTS_CONFIG = {
                 },
                 'children': {
                     'webinars': {
+                        'parent': 'list_webinars',
                         'paginate': False,
                         'path': 'webinars/{webinar_id}',
                         'pk': ['uuid'],
@@ -87,6 +97,7 @@ ENDPOINTS_CONFIG = {
                         },
                         'children': {
                             'webinar_absentees': {
+                                'parent': 'webinars',
                                 'path': 'past_webinars/{webinar_uuid}/absentees',
                                 'pk': ['webinar_uuid', 'id'],
                                 'forced-replication-method': 'FULL_TABLE',
@@ -94,6 +105,7 @@ ENDPOINTS_CONFIG = {
                                 'ignore_http_error_codes': [404]
                             },
                             'webinar_poll_results': {
+                                'parent': 'webinars',
                                 'paginate': False,
                                 'path': 'past_webinars/{webinar_uuid}/polls',
                                 'pk': ['webinar_uuid', 'email'],
@@ -101,6 +113,7 @@ ENDPOINTS_CONFIG = {
                                 'data_key': 'questions'
                             },
                             'webinar_qna_results': {
+                                'parent': 'webinars',
                                 'paginate': False,
                                 'path': 'past_webinars/{webinar_uuid}/qa',
                                 'pk': ['webinar_uuid', 'email'],
@@ -110,24 +123,28 @@ ENDPOINTS_CONFIG = {
                         }
                     },
                     'webinar_panelists': {
+                        'parent': 'list_webinars',
                         'path': 'webinars/{webinar_id}/panelists',
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'panelists'
                     },
                     'webinar_registrants': {
+                        'parent': 'list_webinars',
                         'path': 'webinars/{webinar_id}/registrants',
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'registrants'
                     },
                     'webinar_polls': {
+                        'parent': 'list_webinars',
                         'path': 'webinars/{webinar_id}/polls',
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'polls'
                     },
                     'webinar_questions': {
+                        'parent': 'list_webinars',
                         'paginate': False,
                         'path': 'webinars/{webinar_id}/registrants/questions',
                         'pk': ['webinar_id'],
@@ -135,18 +152,21 @@ ENDPOINTS_CONFIG = {
                         'ignore_zoom_error_codes': [3000]
                     },
                     'webinar_tracking_sources': {
+                        'parent': 'list_webinars',
                         'path': 'webinars/{webinar_id}/tracking_sources',
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',
                         'data_key': 'tracking_sources'
                     },
                     'report_webinars': {
+                        'parent': 'list_webinars',
                         'paginate': False,
                         'path': 'report/webinars/{webinar_id}',
                         'pk': ['uuid'],
                         'forced-replication-method': 'FULL_TABLE',
                     },
                     'report_webinar_participants': {
+                        'parent': 'list_webinars',
                         'path': 'report/webinars/{webinar_id}/participants',
                         'pk': ['webinar_id', 'id'],
                         'forced-replication-method': 'FULL_TABLE',

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,7 +16,6 @@ class ZoomBase(BaseCase):
     """
     PAGE_SIZE = 100000
     PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
-    EXPECTED_PARENT_STREAM = "expected-parent-stream"
 
     @staticmethod
     def tap_name():
@@ -61,128 +60,111 @@ class ZoomBase(BaseCase):
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_meetings"
+                self.PARENT_TAP_STREAM_ID: "list_meetings"
             },
             'meeting_polls': {
                 self.PRIMARY_KEYS: {"meeting_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_meetings"
+                self.PARENT_TAP_STREAM_ID: "list_meetings"
             },
             'meeting_poll_results': {
                 self.PRIMARY_KEYS: {"meeting_uuid", "email"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "meetings"
+                self.PARENT_TAP_STREAM_ID: "meetings"
             },
             'meeting_registrants': {
                 self.PRIMARY_KEYS: {"meeting_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_meetings"
+                self.PARENT_TAP_STREAM_ID: "list_meetings"
             },
             'meeting_questions': {
                 self.PRIMARY_KEYS: {"meeting_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_meetings"
+                self.PARENT_TAP_STREAM_ID: "list_meetings"
             },
             'report_meetings': {
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_meetings"
+                self.PARENT_TAP_STREAM_ID: "list_meetings"
             },
             'report_meeting_participants': {
                 self.PRIMARY_KEYS: {"meeting_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_meetings"
+                self.PARENT_TAP_STREAM_ID: "list_meetings"
             },
             'webinars': {
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-            self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'webinar_absentees': {
                 self.PRIMARY_KEYS: {"webinar_uuid", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "webinars"
+                self.PARENT_TAP_STREAM_ID: "webinars"
             },
             'webinar_poll_results': {
                 self.PRIMARY_KEYS: {"webinar_uuid", "email"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "webinars"
+                self.PARENT_TAP_STREAM_ID: "webinars"
             },
             'webinar_qna_results': {
                 self.PRIMARY_KEYS: {"webinar_uuid", "email"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "webinars"
+                self.PARENT_TAP_STREAM_ID: "webinars"
             },
             'webinar_panelists': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'webinar_registrants': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'webinar_polls': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'webinar_questions': {
                 self.PRIMARY_KEYS: {"webinar_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'webinar_tracking_sources': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'report_webinars': {
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
             'report_webinar_participants': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
-                self.EXPECTED_PARENT_STREAM: "list_webinars"
+                self.PARENT_TAP_STREAM_ID: "list_webinars"
             },
         }
-    
-    def expected_parent_tap_stream_id(self):
-        """
-        Test that expected_metadata contains correct parent-tap-stream-id values.
-        """
-        expected_metadata = self.expected_metadata()
-
-        for stream_name, expected in expected_metadata.items():
-            if self.EXPECTED_PARENT_STREAM in expected:
-                actual_parent = expected.get(self.PARENT_TAP_STREAM_ID)
-                expected_parent = expected.get(self.EXPECTED_PARENT_STREAM)
-                self.assertEqual(
-                    actual_parent,
-                    expected_parent,
-                    msg=f"Stream {stream_name} has parent-tap-stream-id {actual_parent}, "
-                        f"expected {expected_parent}."
-                )
 
     @classmethod
     def setUpClass(cls):

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,6 +15,8 @@ class ZoomBase(BaseCase):
     Shared tap-specific methods (as needed).
     """
     PAGE_SIZE = 100000
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
+    EXPECTED_PARENT_STREAM = "expected-parent-stream"
 
     @staticmethod
     def tap_name():
@@ -59,93 +61,128 @@ class ZoomBase(BaseCase):
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_meetings"
             },
             'meeting_polls': {
                 self.PRIMARY_KEYS: {"meeting_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_meetings"
             },
             'meeting_poll_results': {
                 self.PRIMARY_KEYS: {"meeting_uuid", "email"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "meetings"
             },
             'meeting_registrants': {
                 self.PRIMARY_KEYS: {"meeting_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_meetings"
             },
             'meeting_questions': {
                 self.PRIMARY_KEYS: {"meeting_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_meetings"
             },
             'report_meetings': {
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_meetings"
             },
             'report_meeting_participants': {
                 self.PRIMARY_KEYS: {"meeting_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_meetings"
             },
             'webinars': {
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+            self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'webinar_absentees': {
                 self.PRIMARY_KEYS: {"webinar_uuid", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "webinars"
             },
             'webinar_poll_results': {
                 self.PRIMARY_KEYS: {"webinar_uuid", "email"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "webinars"
             },
             'webinar_qna_results': {
                 self.PRIMARY_KEYS: {"webinar_uuid", "email"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "webinars"
             },
             'webinar_panelists': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'webinar_registrants': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'webinar_polls': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'webinar_questions': {
                 self.PRIMARY_KEYS: {"webinar_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'webinar_tracking_sources': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'report_webinars': {
                 self.PRIMARY_KEYS: {"uuid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
             'report_webinar_participants': {
                 self.PRIMARY_KEYS: {"webinar_id", "id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.RESPECTS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "list_webinars"
             },
         }
+    
+    def expected_parent_tap_stream_id(self):
+        """
+        Test that expected_metadata contains correct parent-tap-stream-id values.
+        """
+        expected_metadata = self.expected_metadata()
+
+        for stream_name, expected in expected_metadata.items():
+            if self.EXPECTED_PARENT_STREAM in expected:
+                actual_parent = expected.get(self.PARENT_TAP_STREAM_ID)
+                expected_parent = expected.get(self.EXPECTED_PARENT_STREAM)
+                self.assertEqual(
+                    actual_parent,
+                    expected_parent,
+                    msg=f"Stream {stream_name} has parent-tap-stream-id {actual_parent}, "
+                        f"expected {expected_parent}."
+                )
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
# Description of change

This PR adds parent stream metadata tracking to the Zoom tap by introducing a new `parent_attribute` field to stream configurations and updating metadata generation to include parent-tap-stream-id information.

Ticket: [SAC-28905](https://qlik-dev.atlassian.net/browse/SAC-28905)

- Added `parent_attribute` field to stream configurations in the flattened streams structure.
- Updated metadata generation to include parent-tap-stream-id when a parent stream exists.

### Changes

| File | Description |
| ---- | ----------- |
| tap_zoom/endpoints.py | Added parent field to stream configurations |
| tap_zoom/discover.py | Added parent_attribute field to both parent and child stream configurations |
| tap_zoom/discover.py | Updated metadata generation to include parent-tap-stream-id for child streams |




---

# Manual QA steps
 You need to comment out the authentication (auth) part in do_discovery, set dev_mode to True, and generate a log file to verify the changes.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
